### PR TITLE
Added correct keybinding description for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ With this extension for Visual Studio Code it's possible to create your todo lis
 ## Keybindings
 Create a checkbox:
 
-> `ctrl + shift + c`
+> `ctrl + shift + c` or ⌘⇧c (Mac)
 
 Toggle checkbox:
 
-> `ctrl + shift + enter`
+> `ctrl + shift + enter` or ⇧Enter (Mac)
 
 
 ## Configuration


### PR DESCRIPTION
After installing the extension, I was unable to use the keybindings. It turns out that the mapping is uses Cmd instead of Ctrl on the Mac.  Updated readme to reflect this.